### PR TITLE
fix readonly error: ts2540 to ts2450

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/typescript-tutorial.iml" filepath="$PROJECT_DIR$/.idea/typescript-tutorial.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/typescript-tutorial.iml
+++ b/.idea/typescript-tutorial.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/basics/type-of-object-interfaces.md
+++ b/basics/type-of-object-interfaces.md
@@ -174,7 +174,7 @@ let xcatliu: Person = {
 
 xcatliu.id = 9527;
 
-// index.ts(14,9): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
+// index.ts(14,9): error TS2450: Cannot assign to 'id' because it is a constant or a read-only property.
 ```
 
 上例中，使用 `readonly` 定义的属性 `id` 初始化后，又被赋值了，所以报错了。


### PR DESCRIPTION
```
interface Person {
  readonly id: number;
  name: string;
  age?: number;
  [propName: string]: any;
}
let xcatliu: Person = {
  id: 89757,
  name: 'Xcat Liu',
  website: 'http://xcatliu.com',
};
xcatliu.id = 9527;

// index.ts(14,9): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
```
应该是TS2450